### PR TITLE
Correct {{ syntax in yaml

### DIFF
--- a/connections/Connection - DateCustom.yml
+++ b/connections/Connection - DateCustom.yml
@@ -2,5 +2,5 @@ unique_name: Connection - DateCustom
 object_type: connection
 label: Connection - DateCustom
 as_connection: Snowflake - AtScale
-database: {{date_database}}
-schema: {{date_schema}}
+database: "{{date_database}}"
+schema: "{{date_schema}}"


### PR DESCRIPTION
`{{` should typically be escaped in yaml.

I'm trying to write a Jackson based parser and this breaks it.